### PR TITLE
Add Downtime Tab to Character Sheet v2 in DND5e 3.0.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IntelliJ IDEs
+.idea
+
 # Logs
 logs
 *.log

--- a/src/scripts/5e-training.js
+++ b/src/scripts/5e-training.js
@@ -53,14 +53,16 @@ async function addTrainingTab(app, html, data) {
     const templateData = getTemplateData(data);
 
     // Create the tab content
+    // ActorSheet5eCharacter2 requires separate templating
     let trainingTabHtml = '';
-    let sheet = html.find(".tab-body");
-    if (app instanceof ActorSheet5eCharacter2) {
-        sheet = html.find(".sheet-body");
+    let sheet = '';
+    if (app instanceof game.dnd5e.applications.actor.ActorSheet5eCharacter2) {
+        sheet = html.find(".tab-body");
         trainingTabHtml = $(
             await renderTemplate(`modules/${CONSTANTS.MODULE_ID}/templates/training-section-v2.hbs`, templateData),
         );
     } else {
+        sheet = html.find(".sheet-body");
         trainingTabHtml = $(
             await renderTemplate(`modules/${CONSTANTS.MODULE_ID}/templates/training-section.hbs`, templateData)
         );

--- a/src/scripts/5e-training.js
+++ b/src/scripts/5e-training.js
@@ -45,7 +45,12 @@ async function addTrainingTab(app, html, data) {
 
     // Update the nav menu
     let tabName = game.settings.get(CONSTANTS.MODULE_ID, "tabName");
-    let trainingTabBtn = $('<a class="item" data-tab="training">' + tabName + "</a>");
+    let trainingTabBtn = '';
+    if (app instanceof game.dnd5e.applications.actor.ActorSheet5eCharacter2) {
+        trainingTabBtn = $(`<a class="item" data-tab="training" data-gorup="primary" data-tooltip="${tabName}"><i class="fas fa-clock"></i></a>`);
+    } else {
+        trainingTabBtn = $('<a class="item" data-tab="training">' + tabName + "</a>")
+    }
     let tabs = html.find('.tabs[data-group="primary"]');
     tabs.append(trainingTabBtn);
 

--- a/src/scripts/lib/lib.js
+++ b/src/scripts/lib/lib.js
@@ -1,4 +1,4 @@
-import CONSTANTS from "../constants";
+import CONSTANTS from "../constants.js";
 
 // ================================
 // Logger utility

--- a/src/scripts/load-templates.js
+++ b/src/scripts/load-templates.js
@@ -9,6 +9,8 @@ export const preloadTemplates = async function () {
         `modules/${CONSTANTS.MODULE_ID}/templates/partials/fixed.hbs`,
         `modules/${CONSTANTS.MODULE_ID}/templates/partials/training-section-contents.hbs`,
         `modules/${CONSTANTS.MODULE_ID}/templates/partials/training-section-contents-world.hbs`,
+        `modules/${CONSTANTS.MODULE_ID}/templates/partials/training-section-contents-v2.hbs`,
+        `modules/${CONSTANTS.MODULE_ID}/templates/partials/training-section-contents-world-v2.hbs`,
     ];
     return loadTemplates(templatePaths);
 };

--- a/src/styles/downtime-dnd5e-training-tab.css
+++ b/src/styles/downtime-dnd5e-training-tab.css
@@ -419,3 +419,82 @@
     text-shadow: none;
     color: rgba(255, 100, 0, 1);
 }
+
+.dnd5e2 .downtime-dnd5e-controls {
+    display: flex;
+    margin: 10px 0 4px 0;
+}
+
+.dnd5e2 .downtime-dnd5e-controls.right {
+    justify-content: flex-end;
+}
+
+.dnd5e2 .downtime-dnd5e-controls button {
+    font-size: var(--font-size-9);
+    /*flex: 1 1;*/
+    white-space: nowrap;
+    color: var(--dnd5e-color-gold);
+    width: min-content;
+}
+
+.dnd5e2 .downtime-dnd5e-controls .spacer {
+    flex: 1 1 10%;
+}
+
+.dnd5e2 .items-section .items-header .activity-type, .dnd5e2 .items-section .item .activity-type {
+    width: 70px;
+}
+
+.dnd5e2 .items-section .items-header .activity-override, .dnd5e2 .items-section .item .activity-override {
+    width: 90px;
+}
+.dnd5e2 .items-section .item .activity-override input {
+    max-width: 50%;
+    text-align: right;
+    display: inline-block;
+    border: 1px var(--dnd5e-background-card) solid;
+}
+.dnd5e2 .items-section .item .activity-override input:hover {
+    border: 1px var(--dnd5e-color-gold) solid;
+}
+
+.dnd5e2 .items-section .items-header .activity-progress, .dnd5e2 .items-section .item .activity-progress {
+    width: 120px;
+}
+
+.dnd5e2 .items-section .item .activity-progress-row .progress-bar {
+    flex: 1 1;
+    background-color: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    height: 20px;
+    margin: 5px;
+}
+
+.dnd5e2 .downtime-dnd5e .items-section .item .activity-progress-row .downtime-dnd5e-completion {
+    color: #111111;
+    background-color: rgba(255, 0, 0, 0.4);
+    border-radius: 4px;
+    height: 100%;
+    line-height: 22px;
+}
+
+.dnd5e2 .downtime-dnd5e .items-section .item .activity-progress-row .downtime-dnd5e-completion span {
+    padding: 0 4px;
+}
+
+.dnd5e2 .items-section .items-header .item-controls, .dnd5e2 .items-section .item .item-controls {
+    width: 75px;
+    gap: 0.25rem;
+    padding: 0;
+}
+
+/* dnd5e dark theme */
+.dnd5e-theme-dark .dnd5e2 .downtime-dnd5e .items-section .item .activity-progress-row .downtime-dnd5e-completion {
+    color: white;
+    background-color: #004aa9;
+    opacity: 0.8;
+}
+
+.dnd5e-theme-dark .dnd5e2 .items-section .item .activity-override input {
+    border: 1px var(--dnd5e-background-card) solid;
+}

--- a/src/templates/partials/training-section-contents-v2.hbs
+++ b/src/templates/partials/training-section-contents-v2.hbs
@@ -146,9 +146,7 @@
                   title="{{downtime-dnd5e-trainingRollBtnTooltip training}}"
               >
                   <img class="item-image gold-icon" src="{{training.img}}">
-                  <div class="name downtime-dnd5e-toggle-desc"
-                       id="downtime-dnd5e-toggle-desc-{{training.id}}"
-                       title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+                  <div class="name" id="downtime-dnd5e-toggle-desc-{{training.id}}">
                       {{#if training.hidden}}
                           <span><i class="fa-solid fa-user-secret"></i></span>
                       {{else}}

--- a/src/templates/partials/training-section-contents-v2.hbs
+++ b/src/templates/partials/training-section-contents-v2.hbs
@@ -1,25 +1,26 @@
 <!-- Tab Controls -->
 {{#if showToUserEditMode}}
-<section class="downtime-dnd5e-controls">
-    <button class="button downtime-dnd5e-export" title="{{ localize 'downtime-dnd5e.ExportTrackedItemsTooltip' }}">
-    <i class="fas fa-file-import"></i> {{ localize 'downtime-dnd5e.ExportTrackedItems' }}
-    </button>
-    {{#if showImportButton}}
-    <button class="button downtime-dnd5e-import" title="{{ localize 'downtime-dnd5e.ImportTrackedItemsTooltip' }}">
-    <i class="fas fa-file-export"></i> {{ localize 'downtime-dnd5e.ImportTrackedItems' }}
-    </button>
-    {{/if}}
-    <button class="button  downtime-dnd5e-audit push-left" title="{{ localize 'downtime-dnd5e.ReviewChanges' }}">
-        <i class="fas fa-clipboard"></i> {{ localize 'downtime-dnd5e.ChangeLog' }}
-    </button>
-    <div class="spacer"></div>
-    <button class="button  downtime-dnd5e-new-category" title="{{ localize 'downtime-dnd5e.CreateNewCategory' }}">
-        <i class="fas fa-list"></i> {{ localize 'downtime-dnd5e.AddCategory' }}
-    </button>
-    <button class="button  downtime-dnd5e-add" title="{{ localize 'downtime-dnd5e.CreateNewItem' }}">
-        <i class="fas fa-plus"></i> {{ localize 'downtime-dnd5e.AddItem' }}
-    </button>
-</section>
+    <section class="downtime-dnd5e-controls">
+        <button class="button downtime-dnd5e-export" title="{{ localize 'downtime-dnd5e.ExportTrackedItemsTooltip' }}">
+            <i class="fas fa-file-import"></i> {{ localize 'downtime-dnd5e.ExportTrackedItems' }}
+        </button>
+        {{#if showImportButton}}
+            <button class="button downtime-dnd5e-import"
+                    title="{{ localize 'downtime-dnd5e.ImportTrackedItemsTooltip' }}">
+                <i class="fas fa-file-export"></i> {{ localize 'downtime-dnd5e.ImportTrackedItems' }}
+            </button>
+        {{/if}}
+        <button class="button  downtime-dnd5e-audit push-left" title="{{ localize 'downtime-dnd5e.ReviewChanges' }}">
+            <i class="fas fa-clipboard"></i> {{ localize 'downtime-dnd5e.ChangeLog' }}
+        </button>
+        <div class="spacer"></div>
+        <button class="button  downtime-dnd5e-new-category" title="{{ localize 'downtime-dnd5e.CreateNewCategory' }}">
+            <i class="fas fa-list"></i> {{ localize 'downtime-dnd5e.AddCategory' }}
+        </button>
+        <button class="button  downtime-dnd5e-add" title="{{ localize 'downtime-dnd5e.CreateNewItem' }}">
+            <i class="fas fa-plus"></i> {{ localize 'downtime-dnd5e.AddItem' }}
+        </button>
+    </section>
 {{/if}}
 
 <!-- Items List -->
@@ -113,96 +114,100 @@
         </ol>
     </div>
 
-  <!-- Categories -->
-  {{#each categoriesActor as |category cid| }}
-  <div class="items-section downtime-list card" title="{{ category.description }}">
-      <div class="items-header header" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
-          <h3 class="item-name" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
-              <span><i class="fa-solid fa-user-check"></i></span> {{ category.name }}
-          </h3>
-          <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
-          <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
-          <div class="item-header activity-progress"></div>
-  {{#if @root.showToUserEditMode}}
-          <div class="item-header item-controls">
-              <a class="item-control downtime-dnd5e-edit-category" id="downtime-dnd5e-edit-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
-              <a class="item-control downtime-dnd5e-delete-category" id="downtime-dnd5e-delete-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
-          </div>
-      </div>
-  {{/if}}
-    <ol class="item-list inventory-list">
-      {{#each (downtime-dnd5e-isInCategory ../actor category) as |training tid| }}
-          <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
-              data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
-              data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
+    <!-- Categories -->
+    {{#each categoriesActor as |category cid| }}
+        <div class="items-section downtime-list card" title="{{ category.description }}">
+        <div class="items-header header" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+            <h3 class="item-name" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+                <span><i class="fa-solid fa-user-check"></i></span> {{ category.name }}
+            </h3>
+            <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+            <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+            <div class="item-header activity-progress"></div>
+            {{#if @root.showToUserEditMode}}
+                <div class="item-header item-controls">
+                    <a class="item-control downtime-dnd5e-edit-category"
+                       id="downtime-dnd5e-edit-category-{{category.id}}"
+                       title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
+                    <a class="item-control downtime-dnd5e-delete-category"
+                       id="downtime-dnd5e-delete-category-{{category.id}}"
+                       title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
+                </div>
+            </div>
+            {{/if}}
+            <ol class="item-list inventory-list">
+                {{#each (downtime-dnd5e-isInCategory ../actor category) as |training tid| }}
+                    <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
+                        data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
+                        data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
 
 
-              {{!-- Item Name --}}
-              <div
-                  class="item-name item-action item-tooltip {{downtime-dnd5e-trainingRollBtnClass training}}"
-                  role="button"
-                  id="downtime-dnd5e-roll-{{training.id}}"
-                  data-action="use"
-                  title="{{downtime-dnd5e-trainingRollBtnTooltip training}}"
-              >
-                  <img class="item-image gold-icon" src="{{training.img}}">
-                  <div class="name" id="downtime-dnd5e-toggle-desc-{{training.id}}">
-                      {{#if training.hidden}}
-                          <span><i class="fa-solid fa-user-secret"></i></span>
-                      {{else}}
-                          <span><i class="fa-solid fa-user"></i></span>
-                      {{/if}}
-                      {{training.name}}
-                  </div>
-              </div>
+                        {{!-- Item Name --}}
+                        <div
+                            class="item-name item-action item-tooltip {{downtime-dnd5e-trainingRollBtnClass training}}"
+                            role="button"
+                            id="downtime-dnd5e-roll-{{training.id}}"
+                            data-action="use"
+                            title="{{downtime-dnd5e-trainingRollBtnTooltip training}}"
+                        >
+                            <img class="item-image gold-icon" src="{{training.img}}">
+                            <div class="name" id="downtime-dnd5e-toggle-desc-{{training.id}}">
+                                {{#if training.hidden}}
+                                    <span><i class="fa-solid fa-user-secret"></i></span>
+                                {{else}}
+                                    <span><i class="fa-solid fa-user"></i></span>
+                                {{/if}}
+                                {{training.name}}
+                            </div>
+                        </div>
 
 
-              <div class="item-detail activity-type activity-type-row">
-                  {{downtime-dnd5e-progressionStyle training ../../actor}}
-              </div>
-              <div class="item-detail activity-override activity-override-row">
-                  {{#if @root.showToUserEditMode}}
-                      <input type="text" class="item-control downtime-dnd5e-override"
-                             id="downtime-dnd5e-override-{{training.id}}"
-                             title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
-                             value="{{training.progress}}" />
-                  {{else}}
-                      <input type="text" readonly class="item-control downtime-dnd5e-override"
-                             id="downtime-dnd5e-override-{{training.id}}"
-                             title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
-                             value="{{training.progress}}" />
-                  {{/if}}
-                  <span> / {{training.completionAt}}</span>
-              </div>
-              <div class="item-detail activity-progress activity-progress-row">
-                  <div class="progress-bar">
-                      <div class="downtime-dnd5e-completion"
-                           style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
-                          <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
-                      </div>
-                  </div>
-              </div>
-              {{#if @root.showToUserEditMode}}
-                  <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
-                      <a class="item-control item-action downtime-dnd5e-edit"
-                         id="downtime-dnd5e-edit-{{training.id}}"
-                         title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
-                      <a class="item-control item-action downtime-dnd5e-delete"
-                         id="downtime-dnd5e-delete-{{training.id}}"
-                         title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
-                      <a class="item-control item-action downtime-dnd5e-move"
-                         id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
-                          class="fas fa-chevron-up"></i></a>
-                      <a class="item-control item-action downtime-dnd5e-move"
-                         id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
-                          class="fas fa-chevron-down"></i></a>
-                  </div>
-              {{/if}}
-          </li>
-      {{/each}}
-    </ol>
-  </div>
-  {{/each}}
+                        <div class="item-detail activity-type activity-type-row">
+                            {{downtime-dnd5e-progressionStyle training ../../actor}}
+                        </div>
+                        <div class="item-detail activity-override activity-override-row">
+                            {{#if @root.showToUserEditMode}}
+                                <input type="text" class="item-control downtime-dnd5e-override"
+                                       id="downtime-dnd5e-override-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                       value="{{training.progress}}" />
+                            {{else}}
+                                <input type="text" readonly class="item-control downtime-dnd5e-override"
+                                       id="downtime-dnd5e-override-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                       value="{{training.progress}}" />
+                            {{/if}}
+                            <span> / {{training.completionAt}}</span>
+                        </div>
+                        <div class="item-detail activity-progress activity-progress-row">
+                            <div class="progress-bar">
+                                <div class="downtime-dnd5e-completion"
+                                     style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                                    <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+                                </div>
+                            </div>
+                        </div>
+                        {{#if @root.showToUserEditMode}}
+                            <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
+                                <a class="item-control item-action downtime-dnd5e-edit"
+                                   id="downtime-dnd5e-edit-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-action downtime-dnd5e-delete"
+                                   id="downtime-dnd5e-delete-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+                                <a class="item-control item-action downtime-dnd5e-move"
+                                   id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
+                                    class="fas fa-chevron-up"></i></a>
+                                <a class="item-control item-action downtime-dnd5e-move"
+                                   id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
+                                    class="fas fa-chevron-down"></i></a>
+                            </div>
+                        {{/if}}
+                    </li>
+                {{/each}}
+            </ol>
+        </div>
+    {{/each}}
 </section>
 
 {{> "modules/downtime-dnd5e/templates/partials/training-section-contents-world-v2.hbs" }}

--- a/src/templates/partials/training-section-contents-v2.hbs
+++ b/src/templates/partials/training-section-contents-v2.hbs
@@ -1,0 +1,210 @@
+<!-- Tab Controls -->
+{{#if showToUserEditMode}}
+<section class="downtime-dnd5e-controls">
+    <button class="button downtime-dnd5e-export" title="{{ localize 'downtime-dnd5e.ExportTrackedItemsTooltip' }}">
+    <i class="fas fa-file-import"></i> {{ localize 'downtime-dnd5e.ExportTrackedItems' }}
+    </button>
+    {{#if showImportButton}}
+    <button class="button downtime-dnd5e-import" title="{{ localize 'downtime-dnd5e.ImportTrackedItemsTooltip' }}">
+    <i class="fas fa-file-export"></i> {{ localize 'downtime-dnd5e.ImportTrackedItems' }}
+    </button>
+    {{/if}}
+    <button class="button  downtime-dnd5e-audit push-left" title="{{ localize 'downtime-dnd5e.ReviewChanges' }}">
+        <i class="fas fa-clipboard"></i> {{ localize 'downtime-dnd5e.ChangeLog' }}
+    </button>
+    <div class="spacer"></div>
+    <button class="button  downtime-dnd5e-new-category" title="{{ localize 'downtime-dnd5e.CreateNewCategory' }}">
+        <i class="fas fa-list"></i> {{ localize 'downtime-dnd5e.AddCategory' }}
+    </button>
+    <button class="button  downtime-dnd5e-add" title="{{ localize 'downtime-dnd5e.CreateNewItem' }}">
+        <i class="fas fa-plus"></i> {{ localize 'downtime-dnd5e.AddItem' }}
+    </button>
+</section>
+{{/if}}
+
+<!-- Items List -->
+<section class="items-list downtime-list">
+
+    <!-- Uncategorized -->
+    <div class="items-section downtime-list card">
+        <div class="items-header header">
+            <h3 class="item-name" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}'
+                data-tooltip-direction='UP'>
+                <span><i class="fa-solid fa-user-check"></i></span> {{ localize 'downtime-dnd5e.Uncategorized' }}
+            </h3>
+            <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+            <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+            <div class="item-header activity-progress"></div>
+            <div class="item-header item-controls"></div>
+        </div>
+        <ol class="item-list inventory-list">
+            {{#each activitiesUnCategorized as |training tid| }}
+
+                <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
+                    data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
+                    data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
+
+
+                    {{!-- Item Name --}}
+                    <div
+                        class="item-name item-action item-tooltip {{downtime-dnd5e-trainingRollBtnClass training}}"
+                        role="button"
+                        id="downtime-dnd5e-roll-{{training.id}}"
+                        data-action="use"
+                        title="{{downtime-dnd5e-trainingRollBtnTooltip training}}"
+                    >
+                        <img class="item-image gold-icon" src="{{training.img}}">
+                        <div class="name downtime-dnd5e-toggle-desc"
+                             id="downtime-dnd5e-toggle-desc-{{training.id}}"
+                             title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+                            {{#if training.hidden}}
+                                <span><i class="fa-solid fa-user-secret"></i></span>
+                            {{else}}
+                                <span><i class="fa-solid fa-user"></i></span>
+                            {{/if}}
+                            {{training.name}}
+                        </div>
+                    </div>
+
+
+                    <div class="item-detail activity-type activity-type-row">
+                        {{downtime-dnd5e-progressionStyle training ../actor}}
+                    </div>
+                    <div class="item-detail activity-override activity-override-row">
+                        {{#if @root.showToUserEditMode}}
+                            <input type="text" class="item-control downtime-dnd5e-override"
+                                   id="downtime-dnd5e-override-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                   value="{{training.progress}}" />
+                        {{else}}
+                            <input type="text" readonly class="item-control downtime-dnd5e-override"
+                                   id="downtime-dnd5e-override-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                   value="{{training.progress}}" />
+                        {{/if}}
+                        <span> / {{training.completionAt}}</span>
+                    </div>
+                    <div class="item-detail activity-progress activity-progress-row">
+                        <div class="progress-bar">
+                            <div class="downtime-dnd5e-completion"
+                                 style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                                <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+                            </div>
+                        </div>
+                    </div>
+                    {{#if @root.showToUserEditMode}}
+                        <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
+                            <a class="item-control item-action downtime-dnd5e-edit"
+                               id="downtime-dnd5e-edit-{{training.id}}"
+                               title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+                            <a class="item-control item-action downtime-dnd5e-delete"
+                               id="downtime-dnd5e-delete-{{training.id}}"
+                               title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+                            <a class="item-control item-action downtime-dnd5e-move"
+                               id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
+                                class="fas fa-chevron-up"></i></a>
+                            <a class="item-control item-action downtime-dnd5e-move"
+                               id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
+                                class="fas fa-chevron-down"></i></a>
+                        </div>
+                    {{/if}}
+                </li>
+            {{/each}}
+        </ol>
+    </div>
+
+  <!-- Categories -->
+  {{#each categoriesActor as |category cid| }}
+  <div class="items-section downtime-list card" title="{{ category.description }}">
+      <div class="items-header header" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+          <h3 class="item-name" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+              <span><i class="fa-solid fa-user-check"></i></span> {{ category.name }}
+          </h3>
+          <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+          <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+          <div class="item-header activity-progress"></div>
+  {{#if @root.showToUserEditMode}}
+          <div class="item-header item-controls">
+              <a class="item-control downtime-dnd5e-edit-category" id="downtime-dnd5e-edit-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
+              <a class="item-control downtime-dnd5e-delete-category" id="downtime-dnd5e-delete-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
+          </div>
+      </div>
+  {{/if}}
+    <ol class="item-list inventory-list">
+      {{#each (downtime-dnd5e-isInCategory ../actor category) as |training tid| }}
+          <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
+              data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
+              data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
+
+
+              {{!-- Item Name --}}
+              <div
+                  class="item-name item-action item-tooltip {{downtime-dnd5e-trainingRollBtnClass training}}"
+                  role="button"
+                  id="downtime-dnd5e-roll-{{training.id}}"
+                  data-action="use"
+                  title="{{downtime-dnd5e-trainingRollBtnTooltip training}}"
+              >
+                  <img class="item-image gold-icon" src="{{training.img}}">
+                  <div class="name downtime-dnd5e-toggle-desc"
+                       id="downtime-dnd5e-toggle-desc-{{training.id}}"
+                       title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+                      {{#if training.hidden}}
+                          <span><i class="fa-solid fa-user-secret"></i></span>
+                      {{else}}
+                          <span><i class="fa-solid fa-user"></i></span>
+                      {{/if}}
+                      {{training.name}}
+                  </div>
+              </div>
+
+
+              <div class="item-detail activity-type activity-type-row">
+                  {{downtime-dnd5e-progressionStyle training ../../actor}}
+              </div>
+              <div class="item-detail activity-override activity-override-row">
+                  {{#if @root.showToUserEditMode}}
+                      <input type="text" class="item-control downtime-dnd5e-override"
+                             id="downtime-dnd5e-override-{{training.id}}"
+                             title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                             value="{{training.progress}}" />
+                  {{else}}
+                      <input type="text" readonly class="item-control downtime-dnd5e-override"
+                             id="downtime-dnd5e-override-{{training.id}}"
+                             title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                             value="{{training.progress}}" />
+                  {{/if}}
+                  <span> / {{training.completionAt}}</span>
+              </div>
+              <div class="item-detail activity-progress activity-progress-row">
+                  <div class="progress-bar">
+                      <div class="downtime-dnd5e-completion"
+                           style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                          <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+                      </div>
+                  </div>
+              </div>
+              {{#if @root.showToUserEditMode}}
+                  <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
+                      <a class="item-control item-action downtime-dnd5e-edit"
+                         id="downtime-dnd5e-edit-{{training.id}}"
+                         title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+                      <a class="item-control item-action downtime-dnd5e-delete"
+                         id="downtime-dnd5e-delete-{{training.id}}"
+                         title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+                      <a class="item-control item-action downtime-dnd5e-move"
+                         id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
+                          class="fas fa-chevron-up"></i></a>
+                      <a class="item-control item-action downtime-dnd5e-move"
+                         id="downtime-dnd5e-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
+                          class="fas fa-chevron-down"></i></a>
+                  </div>
+              {{/if}}
+          </li>
+      {{/each}}
+    </ol>
+  </div>
+  {{/each}}
+</section>
+
+{{> "modules/downtime-dnd5e/templates/partials/training-section-contents-world-v2.hbs" }}

--- a/src/templates/partials/training-section-contents-v2.hbs
+++ b/src/templates/partials/training-section-contents-v2.hbs
@@ -27,7 +27,7 @@
 <section class="items-list downtime-list">
 
     <!-- Uncategorized -->
-    <div class="items-section downtime-list card">
+    <div class="items-section downtime-list card" {{#unless activitiesUnCategorized}}hidden{{/unless}}>
         <div class="items-header header">
             <h3 class="item-name" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}'
                 data-tooltip-direction='UP'>
@@ -38,7 +38,7 @@
             <div class="item-header activity-progress"></div>
             <div class="item-header item-controls"></div>
         </div>
-        <ol class="item-list inventory-list">
+        <ol class="item-list inventory-list" {{#unless activitiesUnCategorized}}hidden{{/unless}}>
             {{#each activitiesUnCategorized as |training tid| }}
 
                 <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"

--- a/src/templates/partials/training-section-contents-world-v2.hbs
+++ b/src/templates/partials/training-section-contents-world-v2.hbs
@@ -1,0 +1,148 @@
+
+
+{{#if @root.isGM}}
+<section class="downtime-dnd5e-controls right">
+        <button class="button  downtime-dnd5e-world-new-category" title="{{ localize 'downtime-dnd5e.CreateNewWorldCategory' }}">
+            <i class="fas fa-list"></i> {{ localize 'downtime-dnd5e.AddWorldCategory' }}
+        </button>
+        <button class="button  downtime-dnd5e-world-add" title="{{ localize 'downtime-dnd5e.CreateNewWorldItem' }}">
+            <i class="fas fa-plus"></i> Add World Downtime
+        </button>
+</section>
+{{/if}}
+
+<!-- Items List -->
+<ol class="items-list">
+
+  <!-- Uncategorized -->
+  <li class="items-header flexrow" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}' data-tooltip-direction='UP'>
+    <div class="item-name flexrow">
+      <h3><span><i class="fa-solid fa-earth-americas"></i></span> {{ localize 'downtime-dnd5e.Uncategorized' }} World Downtimes</h3>
+    </div>
+    <div class="activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+    <div class="activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+    <div class="activity-progress"></div>
+    <div class="downtime-dnd5e-item-controls flexrow"></div>
+  </li>
+  <ol class="item-list inventory-list">
+    {{#each activitiesWorldUnCategorized as |training tid| }}
+      <li class="item flexrow">
+        <div class="item-name flexrow rollable worldRoll" data-tooltip='{{ training.description }}' data-tooltip-direction='UP'>
+          <div class="{{downtime-dnd5e-worldTrainingRollBtnClass training}}"
+                id="downtime-dnd5e-world-roll-{{training.id}}"
+                title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
+                style="background-image: url('{{training.img}}')">
+            <div class="checkmark">  <i class="fas fa-check"></i></div>
+          </div>
+          <h4 class="downtime-dnd5e-world-toggle-desc" id="downtime-dnd5e-world-toggle-desc-{{training.id}}" title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+            {{#if training.hidden}}
+              <span><i class="fa-solid fa-user-secret"></i></span>
+            {{else}}
+              <span><i class="fa-solid fa-user"></i></span>
+            {{/if}}
+            {{training.name}}
+          </h4>
+        </div>
+        <div class="activity-type-row">
+          {{downtime-dnd5e-progressionStyle training ../actor}}
+        </div>
+        <div class="activity-override-row">
+          {{#if @root.showToUserEditMode}}
+          <input type="text" class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
+          {{else}}
+          <input type="text" readonly class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
+          {{/if}}
+          <span> / {{training.completionAt}}</span>
+        </div>
+        <div class="activity-progress-row">
+          <div class="progress-bar">
+            <div class="downtime-dnd5e-completion" style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+              <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+            </div>
+          </div>
+        </div>
+        {{#if @root.showToUserEditMode}}
+        <div class="downtime-dnd5e-item-row-controls worldRoll">
+          {{#if @root.isGM}}
+          <a class="item-control downtime-dnd5e-world-edit" id="downtime-dnd5e-world-edit-{{training.id}}" title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+          <a class="item-control downtime-dnd5e-world-delete" id="downtime-dnd5e-world-delete-{{training.id}}" title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+          {{/if}}
+          <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i class="fas fa-chevron-up"></i></a>
+          <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i class="fas fa-chevron-down"></i></a>
+        </div>
+        {{/if}}
+      </li>
+    {{/each}}
+  </ol>
+
+  <!-- Categories -->
+  {{#each categoriesWorld as |category cid| }}
+    <li class="items-header flexrow" title="{{ category.description }}">
+      <div class="item-name flexrow" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+        <h3><span><i class="fa-solid fa-earth-americas"></i></span> {{ category.name }} World Downtimes</h3>
+      </div>
+      <div class="activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+      <div class="activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+      <div class="activity-progress"></div>
+      {{#if @root.showToUserEditMode}}
+
+      <div class="downtime-dnd5e-item-controls flexrow">
+        {{#if @root.isGM}}
+        <a class="item-control downtime-dnd5e-world-edit-category" id="downtime-dnd5e-world-edit-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
+        <a class="item-control downtime-dnd5e-world-delete-category" id="downtime-dnd5e-world-delete-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
+        {{/if}}
+      </div>
+      {{/if}}
+    </li>
+    <ol class="item-list inventory-list">
+      {{#each (downtime-dnd5e-isInWorldCategory ../actor category) as |training tid| }}
+        <li class="item flexrow">
+          <div class="item-name flexrow rollable worldRoll" data-tooltip='{{ training.description }}' data-tooltip-direction='UP'>
+            <div class="{{downtime-dnd5e-worldTrainingRollBtnClass training}}"
+                  id="downtime-dnd5e-world-roll-{{training.id}}"
+                  title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
+                  style="background-image: url('{{training.img}}')">
+              <div class="checkmark">  <i class="fas fa-check"></i></div>
+            </div>
+            <h4 class="downtime-dnd5e-world-toggle-desc" id="downtime-dnd5e-world-toggle-desc-{{training.id}}" title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+              {{#if training.hidden}}
+                <span><i class="fa-solid fa-user-secret"></i></span>
+              {{else}}
+                <span><i class="fa-solid fa-user"></i></span>
+              {{/if}}
+              {{training.name}}
+            </h4>
+          </div>
+          <div class="activity-type-row">
+            {{downtime-dnd5e-progressionStyle training ../../actor}}
+          </div>
+          <div class="activity-override-row">
+            {{#if @root.showToUserEditMode}}
+            <input type="text" class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
+            {{else}}
+            <input type="text" readonly class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
+            {{/if}}
+            <span> / {{training.completionAt}}</span>
+          </div>
+          <div class="activity-progress-row">
+            <div class="progress-bar">
+              <div class="downtime-dnd5e-completion" style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+              </div>
+            </div>
+          </div>
+          {{#if @root.showToUserEditMode}}
+          <div class="downtime-dnd5e-item-row-controls worldRoll">
+            {{#if @root.isGM}}
+              <a class="item-control downtime-dnd5e-world-edit" id="downtime-dnd5e-world-edit-{{training.id}}" title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+              <a class="item-control downtime-dnd5e-world-delete" id="downtime-dnd5e-world-delete-{{training.id}}" title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+            {{/if}}
+            <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i class="fas fa-chevron-up"></i></a>
+            <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i class="fas fa-chevron-down"></i></a>
+          </div>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ol>
+  {{/each}}
+</ol>

--- a/src/templates/partials/training-section-contents-world-v2.hbs
+++ b/src/templates/partials/training-section-contents-world-v2.hbs
@@ -15,7 +15,7 @@
 <section class="items-list downtime-list">
 
     <!-- Uncategorized -->
-    <div class="items-section downtime-list card">
+    <div class="items-section downtime-list card" {{#unless activitiesWorldUnCategorized}}hidden{{/unless}}>
         <div class="items-header header">
             <h3 class="item-name" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}'
                 data-tooltip-direction='UP'>
@@ -27,7 +27,7 @@
             <div class="item-header activity-progress"></div>
             <div class="item-header item-controls"></div>
         </div>
-        <ol class="item-list inventory-list">
+        <ol class="item-list inventory-list" {{#unless activitiesWorldUnCategorized}}hidden{{/unless}}>
             {{#each activitiesWorldUnCategorized as |training tid| }}
 
                 <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"

--- a/src/templates/partials/training-section-contents-world-v2.hbs
+++ b/src/templates/partials/training-section-contents-world-v2.hbs
@@ -1,148 +1,207 @@
-
-
 {{#if @root.isGM}}
-<section class="downtime-dnd5e-controls right">
-        <button class="button  downtime-dnd5e-world-new-category" title="{{ localize 'downtime-dnd5e.CreateNewWorldCategory' }}">
+    <section class="downtime-dnd5e-controls right">
+        <button class="button  downtime-dnd5e-world-new-category"
+                title="{{ localize 'downtime-dnd5e.CreateNewWorldCategory' }}">
             <i class="fas fa-list"></i> {{ localize 'downtime-dnd5e.AddWorldCategory' }}
         </button>
         <button class="button  downtime-dnd5e-world-add" title="{{ localize 'downtime-dnd5e.CreateNewWorldItem' }}">
             <i class="fas fa-plus"></i> Add World Downtime
         </button>
-</section>
+    </section>
 {{/if}}
 
 <!-- Items List -->
-<ol class="items-list">
 
-  <!-- Uncategorized -->
-  <li class="items-header flexrow" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}' data-tooltip-direction='UP'>
-    <div class="item-name flexrow">
-      <h3><span><i class="fa-solid fa-earth-americas"></i></span> {{ localize 'downtime-dnd5e.Uncategorized' }} World Downtimes</h3>
+<section class="items-list downtime-list">
+
+    <!-- Uncategorized -->
+    <div class="items-section downtime-list card">
+        <div class="items-header header">
+            <h3 class="item-name" data-tooltip='{{ localize 'downtime-dnd5e.Uncategorized' }}'
+                data-tooltip-direction='UP'>
+                <span><i class="fa-solid fa-earth-americas"></i></span> {{ localize 'downtime-dnd5e.Uncategorized' }}
+                World Downtimes
+            </h3>
+            <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+            <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+            <div class="item-header activity-progress"></div>
+            <div class="item-header item-controls"></div>
+        </div>
+        <ol class="item-list inventory-list">
+            {{#each activitiesWorldUnCategorized as |training tid| }}
+
+                <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
+                    data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
+                    data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
+
+
+                    {{!-- Item Name --}}
+                    <div
+                        class="item-name item-action item-tooltip {{downtime-dnd5e-worldTrainingRollBtnClass training}}"
+                        role="button"
+                        id="downtime-dnd5e-world-roll-{{training.id}}"
+                        data-action="use"
+                        title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
+                    >
+                        <img class="item-image gold-icon" src="{{training.img}}">
+                        <div class="name downtime-dnd5e-toggle-desc"
+                             id="downtime-dnd5e-world-toggle-desc-{{training.id}}"
+                             title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
+                            {{#if training.hidden}}
+                                <span><i class="fa-solid fa-user-secret"></i></span>
+                            {{else}}
+                                <span><i class="fa-solid fa-user"></i></span>
+                            {{/if}}
+                            {{training.name}}
+                        </div>
+                    </div>
+
+
+                    <div class="item-detail activity-type activity-type-row">
+                        {{downtime-dnd5e-progressionStyle training ../actor}}
+                    </div>
+                    <div class="item-detail activity-override activity-override-row">
+                        {{#if @root.showToUserEditMode}}
+                            <input type="text" class="item-control downtime-dnd5e-world-override"
+                                   id="downtime-dnd5e-world-override-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                   value="{{training.progress}}" />
+                        {{else}}
+                            <input type="text" readonly class="item-control downtime-dnd5e-world-override"
+                                   id="downtime-dnd5e-world-override-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                   value="{{training.progress}}" />
+                        {{/if}}
+                        <span> / {{training.completionAt}}</span>
+                    </div>
+                    <div class="item-detail activity-progress activity-progress-row">
+                        <div class="progress-bar">
+                            <div class="downtime-dnd5e-completion"
+                                 style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                                <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+                            </div>
+                        </div>
+                    </div>
+                    {{#if @root.showToUserEditMode}}
+                        <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
+                            {{#if @root.isGM}}
+                                <a class="item-control item-action downtime-dnd5e-world-edit"
+                                   id="downtime-dnd5e-world-edit-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-action downtime-dnd5e-world-delete"
+                                   id="downtime-dnd5e-world-delete-{{training.id}}"
+                                   title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
+                            {{/if}}
+                            <a class="item-control item-action downtime-dnd5e-world-move"
+                               id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
+                                class="fas fa-chevron-up"></i></a>
+                            <a class="item-control item-action downtime-dnd5e-world-move"
+                               id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
+                                class="fas fa-chevron-down"></i></a>
+                        </div>
+                    {{/if}}
+                </li>
+            {{/each}}
+        </ol>
     </div>
-    <div class="activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
-    <div class="activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
-    <div class="activity-progress"></div>
-    <div class="downtime-dnd5e-item-controls flexrow"></div>
-  </li>
-  <ol class="item-list inventory-list">
-    {{#each activitiesWorldUnCategorized as |training tid| }}
-      <li class="item flexrow">
-        <div class="item-name flexrow rollable worldRoll" data-tooltip='{{ training.description }}' data-tooltip-direction='UP'>
-          <div class="{{downtime-dnd5e-worldTrainingRollBtnClass training}}"
-                id="downtime-dnd5e-world-roll-{{training.id}}"
-                title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
-                style="background-image: url('{{training.img}}')">
-            <div class="checkmark">  <i class="fas fa-check"></i></div>
-          </div>
-          <h4 class="downtime-dnd5e-world-toggle-desc" id="downtime-dnd5e-world-toggle-desc-{{training.id}}" title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
-            {{#if training.hidden}}
-              <span><i class="fa-solid fa-user-secret"></i></span>
-            {{else}}
-              <span><i class="fa-solid fa-user"></i></span>
-            {{/if}}
-            {{training.name}}
-          </h4>
-        </div>
-        <div class="activity-type-row">
-          {{downtime-dnd5e-progressionStyle training ../actor}}
-        </div>
-        <div class="activity-override-row">
-          {{#if @root.showToUserEditMode}}
-          <input type="text" class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
-          {{else}}
-          <input type="text" readonly class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
-          {{/if}}
-          <span> / {{training.completionAt}}</span>
-        </div>
-        <div class="activity-progress-row">
-          <div class="progress-bar">
-            <div class="downtime-dnd5e-completion" style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
-              <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+
+    <!-- Categories -->
+    {{#each categoriesWorld as |category cid| }}
+        <div class="items-section downtime-list card" title="{{ category.description }}">
+            <div class="items-header header" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+                <h3 class="item-name" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
+                    <span><i class="fa-solid fa-earth-americas"></i></span> {{ category.name }} World Downtimes
+                </h3>
+                <div class="item-header activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
+                <div class="item-header activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
+                <div class="item-header activity-progress"></div>
+                {{#if @root.showToUserEditMode}}
+                    <div class="item-header item-controls">
+                        {{#if @root.isGM}}
+                            <a class="item-control downtime-dnd5e-world-edit-category"
+                               id="downtime-dnd5e-world-edit-category-{{category.id}}"
+                               title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
+                            <a class="item-control downtime-dnd5e-world-delete-category"
+                               id="downtime-dnd5e-world-delete-category-{{category.id}}"
+                               title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
+                        {{/if}}
+                    </div>
+                {{/if}}
             </div>
-          </div>
+            <ol class="item-list inventory-list">
+                {{#each (downtime-dnd5e-isInWorldCategory ../actor category) as |training tid| }}
+                    <li class="item" data-item-id="{{ item.id }}" data-entry-id="{{ item.id }}"
+                        data-item-name="{{ item.name }}" data-item-sort="{{ item.sort }}" data-grouped="{{ ctx.group }}"
+                        data-ungrouped="{{#if ../hasActions}}active{{else}}passive{{/if}}">
+
+
+                        {{!-- Item Name --}}
+                        <div
+                            class="item-name item-action item-tooltip {{downtime-dnd5e-worldTrainingRollBtnClass training}}"
+                            role="button"
+                            id="downtime-dnd5e-world-roll-{{training.id}}"
+                            data-action="use"
+                            title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
+                        >
+                            <img class="item-image gold-icon" src="{{training.img}}">
+                            <div class="name" id="downtime-dnd5e-world-toggle-desc-{{training.id}}">
+                                {{#if training.hidden}}
+                                    <span><i class="fa-solid fa-user-secret"></i></span>
+                                {{else}}
+                                    <span><i class="fa-solid fa-user"></i></span>
+                                {{/if}}
+                                {{training.name}}
+                            </div>
+                        </div>
+
+
+                        <div class="item-detail activity-type activity-type-row">
+                            {{downtime-dnd5e-progressionStyle training ../../actor}}
+                        </div>
+                        <div class="item-detail activity-override activity-override-row">
+                            {{#if @root.showToUserEditMode}}
+                                <input type="text" class="item-control downtime-dnd5e-world-override"
+                                       id="downtime-dnd5e-world-override-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                       value="{{training.progress}}" />
+                            {{else}}
+                                <input type="text" readonly class="item-control downtime-dnd5e-world-override"
+                                       id="downtime-dnd5e-world-override-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}"
+                                       value="{{training.progress}}" />
+                            {{/if}}
+                            <span> / {{training.completionAt}}</span>
+                        </div>
+                        <div class="item-detail activity-progress activity-progress-row">
+                            <div class="progress-bar">
+                                <div class="downtime-dnd5e-completion"
+                                     style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
+                                    <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
+                                </div>
+                            </div>
+                        </div>
+                        {{#if @root.showToUserEditMode}}
+                            <div class="item-detail item-controls downtime-dnd5e-item-row-controls">
+                                {{#if @root.isGM}}
+                                    <a class="item-control item-action downtime-dnd5e-world-edit"
+                                       id="downtime-dnd5e-world-edit-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
+                                    <a class="item-control item-action downtime-dnd5e-world-delete"
+                                       id="downtime-dnd5e-world-delete-{{training.id}}"
+                                       title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i
+                                        class="fas fa-trash"></i></a>
+                                {{/if}}
+                                <a class="item-control item-action downtime-dnd5e-world-move"
+                                   id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i
+                                    class="fas fa-chevron-up"></i></a>
+                                <a class="item-control item-action downtime-dnd5e-world-move"
+                                   id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i
+                                    class="fas fa-chevron-down"></i></a>
+                            </div>
+                        {{/if}}
+                    </li>
+                {{/each}}
+            </ol>
         </div>
-        {{#if @root.showToUserEditMode}}
-        <div class="downtime-dnd5e-item-row-controls worldRoll">
-          {{#if @root.isGM}}
-          <a class="item-control downtime-dnd5e-world-edit" id="downtime-dnd5e-world-edit-{{training.id}}" title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
-          <a class="item-control downtime-dnd5e-world-delete" id="downtime-dnd5e-world-delete-{{training.id}}" title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
-          {{/if}}
-          <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i class="fas fa-chevron-up"></i></a>
-          <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i class="fas fa-chevron-down"></i></a>
-        </div>
-        {{/if}}
-      </li>
     {{/each}}
-  </ol>
-
-  <!-- Categories -->
-  {{#each categoriesWorld as |category cid| }}
-    <li class="items-header flexrow" title="{{ category.description }}">
-      <div class="item-name flexrow" data-tooltip='{{ category.description }}' data-tooltip-direction='UP'>
-        <h3><span><i class="fa-solid fa-earth-americas"></i></span> {{ category.name }} World Downtimes</h3>
-      </div>
-      <div class="activity-type">{{localize "downtime-dnd5e.CheckTypeColumnHeader"}}</div>
-      <div class="activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
-      <div class="activity-progress"></div>
-      {{#if @root.showToUserEditMode}}
-
-      <div class="downtime-dnd5e-item-controls flexrow">
-        {{#if @root.isGM}}
-        <a class="item-control downtime-dnd5e-world-edit-category" id="downtime-dnd5e-world-edit-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>
-        <a class="item-control downtime-dnd5e-world-delete-category" id="downtime-dnd5e-world-delete-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.DeleteCategory' }}"><i class="fas fa-trash"></i></a>
-        {{/if}}
-      </div>
-      {{/if}}
-    </li>
-    <ol class="item-list inventory-list">
-      {{#each (downtime-dnd5e-isInWorldCategory ../actor category) as |training tid| }}
-        <li class="item flexrow">
-          <div class="item-name flexrow rollable worldRoll" data-tooltip='{{ training.description }}' data-tooltip-direction='UP'>
-            <div class="{{downtime-dnd5e-worldTrainingRollBtnClass training}}"
-                  id="downtime-dnd5e-world-roll-{{training.id}}"
-                  title="{{downtime-dnd5e-worldTrainingRollBtnTooltip training}}"
-                  style="background-image: url('{{training.img}}')">
-              <div class="checkmark">  <i class="fas fa-check"></i></div>
-            </div>
-            <h4 class="downtime-dnd5e-world-toggle-desc" id="downtime-dnd5e-world-toggle-desc-{{training.id}}" title="{{ localize 'downtime-dnd5e.ToggleInfo' }}">
-              {{#if training.hidden}}
-                <span><i class="fa-solid fa-user-secret"></i></span>
-              {{else}}
-                <span><i class="fa-solid fa-user"></i></span>
-              {{/if}}
-              {{training.name}}
-            </h4>
-          </div>
-          <div class="activity-type-row">
-            {{downtime-dnd5e-progressionStyle training ../../actor}}
-          </div>
-          <div class="activity-override-row">
-            {{#if @root.showToUserEditMode}}
-            <input type="text" class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
-            {{else}}
-            <input type="text" readonly class="item-control downtime-dnd5e-world-override" id="downtime-dnd5e-world-override-{{training.id}}" title="{{ localize 'downtime-dnd5e.AdjustProgressValue' }}" value="{{training.progress}}"/>
-            {{/if}}
-            <span> / {{training.completionAt}}</span>
-          </div>
-          <div class="activity-progress-row">
-            <div class="progress-bar">
-              <div class="downtime-dnd5e-completion" style="width:{{downtime-dnd5e-trainingCompletion training}}%;">
-                <span>{{downtime-dnd5e-trainingCompletion training}}%</span>
-              </div>
-            </div>
-          </div>
-          {{#if @root.showToUserEditMode}}
-          <div class="downtime-dnd5e-item-row-controls worldRoll">
-            {{#if @root.isGM}}
-              <a class="item-control downtime-dnd5e-world-edit" id="downtime-dnd5e-world-edit-{{training.id}}" title="{{ localize 'downtime-dnd5e.EditItem' }}"><i class="fas fa-edit"></i></a>
-              <a class="item-control downtime-dnd5e-world-delete" id="downtime-dnd5e-world-delete-{{training.id}}" title="{{ localize 'downtime-dnd5e.DeleteItem' }}"><i class="fas fa-trash"></i></a>
-            {{/if}}
-            <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Up"><i class="fas fa-chevron-up"></i></a>
-            <a class="item-control downtime-dnd5e-world-move" id="downtime-dnd5e-world-move-{{training.id}}" data-tid={{tid}} title="Move Activity Down"><i class="fas fa-chevron-down"></i></a>
-          </div>
-          {{/if}}
-        </li>
-      {{/each}}
-    </ol>
-  {{/each}}
-</ol>
+</section>

--- a/src/templates/partials/training-section-contents-world.hbs
+++ b/src/templates/partials/training-section-contents-world.hbs
@@ -72,7 +72,7 @@
       <div class="activity-override">{{localize "downtime-dnd5e.ProgressColumnHeader"}}</div>
       <div class="activity-progress"></div>
       {{#if @root.showToUserEditMode}}
-      
+
       <div class="downtime-dnd5e-item-controls flexrow">
         {{#if @root.isGM}}
         <a class="item-control downtime-dnd5e-world-edit-category" id="downtime-dnd5e-world-edit-category-{{category.id}}" title="{{ localize 'downtime-dnd5e.EditCategory' }}"><i class="fas fa-edit"></i></a>

--- a/src/templates/training-section-v2.hbs
+++ b/src/templates/training-section-v2.hbs
@@ -1,0 +1,3 @@
+<div class="tab downtime-dnd5e" data-group="primary" data-tab="training">
+  {{> "modules/downtime-dnd5e/templates/partials/training-section-contents-v2.hbs" }}
+</div>


### PR DESCRIPTION
- Resolves #11

Creating Pull Request as a draft for now, because it's not finished (still need to do World Downtime and testing)


## Current WiP status:
Showing next to NPC for comparison, as their Actor Sheet remained the same
**Light Mode**
![light mode wip status](https://github.com/p4535992/foundryvtt-downtime-dnd5e/assets/11304207/4adeeb18-558a-479e-9c5a-1ca444bb8d6e)

**Dark Mode**
![image](https://github.com/p4535992/foundryvtt-downtime-dnd5e/assets/11304207/f4766941-7c8e-4f0b-ab83-e1dcbf568432)

